### PR TITLE
Switch to a custom gatekeeper again

### DIFF
--- a/k8s/templates/gatekeeper.yaml
+++ b/k8s/templates/gatekeeper.yaml
@@ -14,7 +14,7 @@ spec:
         name: gatekeeper
     spec:
       containers:
-        - image: 320464205386.dkr.ecr.us-west-2.amazonaws.com/keycloak-gatekeeper:samesitelax
+        - image: 320464205386.dkr.ecr.us-west-2.amazonaws.com/keycloak-gatekeeper:fixstate
           imagePullPolicy: Always
           name: gatekeeper
           ports:


### PR DESCRIPTION
in order to mitigate the cookie mess we move to a custom build
of keycloak again, changes will be upstreamed

repo: https://github.com/fiji-flo/keycloak-gatekeeper/tree/hardcode-state-cookie-name