### PR TITLE
don't send to gatekeeper by default

### DIFF
--- a/k8s/templates/ingress.yaml
+++ b/k8s/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: gatekeeper
+          serviceName: wants-gatekeeper
           servicePort: 80
       - path: /reload.html
         backend:

--- a/k8s/templates/wants-gatekeeper.yaml
+++ b/k8s/templates/wants-gatekeeper.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wants-gatekeeper
+  namespace: {{ .Values.namespace }}
+data:
+  nginx.conf: |
+    worker_rlimit_nofile 8192;
+
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+
+    http {
+      proxy_redirect          off;
+      proxy_set_header        Host            $host;
+      proxy_set_header        X-Real-IP       $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      client_max_body_size    32m;
+      client_body_buffer_size 128k;
+      proxy_connect_timeout   90;
+      proxy_send_timeout      90;
+      proxy_read_timeout      90;
+      proxy_buffers           32 4k;
+      resolver                127.0.0.11; // proxy_pass with variables needs a resolver
+
+      map $http_cookie $target {
+        default "nginx-router:80/welcome.html";
+
+        "~*pmo-auto-login=1" "gatekeeper:80";
+        "~*pmo-access=([^;]+)" "gatekeeper:80";
+      }
+
+      server {
+        listen 80;
+
+        location / {
+          proxy_pass http://$target;
+        }
+      }
+    }
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wants-gatekeeper
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: wants-gatekeeper
+spec:
+  replicas: {{ .Values.router_replicas }}
+  template:
+    metadata:
+      labels:
+        app: wants-gatekeeper
+    spec:
+      volumes:
+      - name: wants-gatekeeper
+        configMap:
+          name: wants-gatekeeper
+      containers:
+      - name: wants-gatekeeper
+        image: nginx
+        ports:
+        - name: http
+          containerPort: 80
+        env:
+        - name: force_update
+          value: "3"
+        volumeMounts:
+        - name: wants-gatekeeper
+          mountPath: /etc/nginx/
+          readOnly: true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    name: wants-gatekeeper
+  name: wants-gatekeeper
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  selector:
+    app: wants-gatekeeper


### PR DESCRIPTION
New users shouldn't be sent to gatekeeper by default, but only if they already have a session or set the specific cookie.

When using variables in a `proxy_pass` in nginx, a resolver is required. This https://stackoverflow.com/questions/17685674/nginx-proxy-pass-with-remote-addr#comment101485162_22259088 states that docker by default runs it's DNS service on `127.0.0.11` so I hope setting the resolver to that will work.