### PR TITLE
Keep only last 30 images; safe money

### DIFF
--- a/terraform/codebuild/main.tf
+++ b/terraform/codebuild/main.tf
@@ -165,3 +165,25 @@ EOF
 
 }
 
+resource "aws_ecr_lifecycle_policy" "keep-30" {
+  repository = aws_ecr_repository.registry.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}


### PR DESCRIPTION
This Pull Request will enable a lifecycle rule which will keep only the last 30 images pushed to the repository, regardless of the tag they have.
This will decrease our cost on storage.

We can go fancy adding different rules for different tag. Let me know what do you think