### PR TITLE
dev: internal URL for fossil was incorrect

### DIFF
--- a/dev/settings.json
+++ b/dev/settings.json
@@ -33,7 +33,7 @@
       "internal_update_enabled": false
     },
     "fossil": {
-      "upload_endpoint": "https://fossil:8083/avatar/internal/"
+      "upload_endpoint": "https://fossil:8083/internal/"
     },
     "search": {
       "simple_endpoint": "https://search:8889/search/simple/"


### PR DESCRIPTION
Note the lack of `/avatar/` in the URL here: https://github.com/mozilla-iam/dino-park-fence/blob/713d8fdcd44deea7f862bee318a1a61c993adf33/k8s/values.yaml#L14

Jira: IAM-1908